### PR TITLE
[fix]MySQL環境でのtext型カラムのデフォルト値指定方法を調整

### DIFF
--- a/app/models/discuss_record.rb
+++ b/app/models/discuss_record.rb
@@ -1,4 +1,5 @@
 class DiscussRecord < ApplicationRecord
+  attribute :detail, :text, default: ''
 
   belongs_to :pair
   has_many :personal_opinions, dependent: :destroy

--- a/app/models/pair.rb
+++ b/app/models/pair.rb
@@ -1,5 +1,5 @@
 class Pair < ApplicationRecord
-
+  attribute :motto, :text, default: 'もっと～！'
   has_many :users, dependent: :destroy
   has_many :tags, dependent: :destroy
   has_many :discuss_records, dependent: :destroy

--- a/app/models/personal_opinion.rb
+++ b/app/models/personal_opinion.rb
@@ -1,5 +1,6 @@
 class PersonalOpinion < ApplicationRecord
-  
+  attribute :claim, :text, default: ''
+  attribute :conclude, :text, default: ''
   belongs_to :discuss_record
   belongs_to :user
   

--- a/db/migrate/20220309061422_devise_create_users.rb
+++ b/db/migrate/20220309061422_devise_create_users.rb
@@ -10,7 +10,7 @@ class DeviseCreateUsers < ActiveRecord::Migration[6.1]
       t.integer :oko_gauge, null: false, default: 0
       t.string :email,              null: false, default: ""
       t.string :encrypted_password, null: false, default: ""
-      t.boolean :is_active, null: false, default: TRUE
+      t.boolean :is_active, null: false, default: true
 
 
       ## Recoverable

--- a/db/migrate/20220309074450_create_pairs.rb
+++ b/db/migrate/20220309074450_create_pairs.rb
@@ -2,10 +2,10 @@ class CreatePairs < ActiveRecord::Migration[6.1]
   def change
     create_table :pairs do |t|
       t.string :name, null: false, default: ""
-      t.text :motto, null: false, default: ""
+      t.text :motto, null: false
       t.string :keyword, null:false, default:""
       t.integer :pair_type, null: false, default: 0
-      t.boolean :is_paired, null: false, default: FALSE
+      t.boolean :is_paired, null: false, default: false
       t.integer :rank, null: false, default: 0
       t.timestamps
     end

--- a/db/migrate/20220309074525_create_discuss_records.rb
+++ b/db/migrate/20220309074525_create_discuss_records.rb
@@ -3,8 +3,8 @@ class CreateDiscussRecords < ActiveRecord::Migration[6.1]
     create_table :discuss_records do |t|
       t.integer :pair_id, null: false
       t.string :title, null: false, default: ""
-      t.text :detail, null: false, default: ""
-      t.boolean :is_closed, null: false, default: FALSE
+      t.text :detail, null: false
+      t.boolean :is_closed, null: false, default: false
       t.timestamps
     end
   end

--- a/db/migrate/20220309074542_create_personal_opinions.rb
+++ b/db/migrate/20220309074542_create_personal_opinions.rb
@@ -3,8 +3,8 @@ class CreatePersonalOpinions < ActiveRecord::Migration[6.1]
     create_table :personal_opinions do |t|
       t.integer :discuss_record_id, null: false
       t.integer :user_id, null: false
-      t.text :claim, null: false, default: ""
-      t.text :conclude, null: false, default: ""
+      t.text :claim, null: false
+      t.text :conclude, null: false
       t.timestamps
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -43,7 +43,7 @@ ActiveRecord::Schema.define(version: 2022_03_12_051650) do
   create_table "discuss_records", force: :cascade do |t|
     t.integer "pair_id", null: false
     t.string "title", default: "", null: false
-    t.text "detail", default: "", null: false
+    t.text "detail", null: false
     t.boolean "is_closed", default: false, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
@@ -51,7 +51,7 @@ ActiveRecord::Schema.define(version: 2022_03_12_051650) do
 
   create_table "pairs", force: :cascade do |t|
     t.string "name", default: "", null: false
-    t.text "motto", default: "", null: false
+    t.text "motto", null: false
     t.string "keyword", default: "", null: false
     t.integer "pair_type", default: 0, null: false
     t.boolean "is_paired", default: false, null: false
@@ -63,8 +63,8 @@ ActiveRecord::Schema.define(version: 2022_03_12_051650) do
   create_table "personal_opinions", force: :cascade do |t|
     t.integer "discuss_record_id", null: false
     t.integer "user_id", null: false
-    t.text "claim", default: "", null: false
-    t.text "conclude", default: "", null: false
+    t.text "claim", null: false
+    t.text "conclude", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,25 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+
+User.create!(
+  [
+    # pair1 二人ともアクティブ
+    {partner_id: 2, pair_id:1, email: '1@1', name: 'user1', password: 'kinoko', oko_gauge: 0, is_active: true},
+    {partner_id: 1, pair_id:1, email: '2@2', name: 'user2', password: 'kinoko', oko_gauge: 0, is_active: true},
+    # pair2 片方が退会
+    {partner_id: 4, pair_id:2, email: '3@3', name: 'user3', password: 'kinoko', oko_gauge: 0, is_active: true},
+    {partner_id: 3, pair_id:2, email: '4@4', name: 'user4', password: 'kinoko', oko_gauge: 0, is_active: false},
+    # pair3 一人しか登録していない
+    {partner_id: nil, pair_id:3, email: '5@5', name: 'user5', password: 'kinoko', oko_gauge: 0, is_active: true}
+  ]
+)
+
+
+Pair.create!(
+  [
+    {name: 'pair1', motto: 'なかよくしよう', pair_type: 0, rank: 0, is_paired: true},
+    {name: 'pair2', motto: '一日一笑', pair_type: 0, rank: 0, is_paired: true},
+    {name: 'pair3', motto: 'いい夫婦', pair_type: 0, rank: 0, is_paired: false}
+  ]
+)


### PR DESCRIPTION
- マイグレーションファイルのtext型項目のdefault指定を削除
- 各モデルファイルにattribute記述、Rails側でdefault値指定